### PR TITLE
#id -> #gdb_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ front_boxart.url
 Available Properties
 --------------------
 
-    game.id
+    game.gbd_id
     game.title
     game.overview
     game.platform

--- a/lib/the_games_db/game.rb
+++ b/lib/the_games_db/game.rb
@@ -5,7 +5,7 @@ module TheGamesDB
     include SAXMachine
 
     parent   :feed
-    element  :id
+    element  :id           :as => :gbd_id
     element  :GameTitle,   :as => :title
     element  :Overview,    :as => :overview
     element  :Platform,    :as => :platform

--- a/spec/the_games_db/game_spec.rb
+++ b/spec/the_games_db/game_spec.rb
@@ -52,7 +52,7 @@ describe TheGamesDB::Game do
     let(:game) { TheGamesDB::Game.find 140 }
 
     it 'correctly parses the values' do
-      game.id.should == "140"
+      game.gbd_id.should == "140"
       game.title.should == "Super Mario Bros."
       game.overview.should =~ /^The player takes the role of Mario/
       game.platform.should == "Nintendo Entertainment System (NES)"


### PR DESCRIPTION
This pull changes the `id` attribute to `gdb_id`.

While this works in normal Ruby scripts, its generally a bad idea to overwrite `#id`. 

Mostly, I just found problems using this library inside of Rails because of this. It kept outputting the `#object_id`. No clue why its freaking out like that. I guess this is just why it's a bad idea to do.
