### PR TITLE
Release Date Fix: convert year, month and day to integers.

### DIFF
--- a/lib/the_games_db/game.rb
+++ b/lib/the_games_db/game.rb
@@ -40,7 +40,7 @@ module TheGamesDB
       return unless @release_date
 
       month, day, year = @release_date.split('/').map(&:to_i)
-      Date.civil year, month, day
+      Date.civil year.to_i, month.to_i, day.to_i
     end
 
   end


### PR DESCRIPTION
It seems so, that sometimes The Games DB (or this gem) returns date strings. I fixed this by converting them to integers.

Exception was: NoMethodError: undefined method `div' for nil:NilClass
